### PR TITLE
Add midiDevices to query available devices

### DIFF
--- a/src/FRP/Event/MIDI.js
+++ b/src/FRP/Event/MIDI.js
@@ -1,6 +1,28 @@
 exports.midiAccess = function () {
-  return navigator.requestMIDIAccess();
-};
+  return navigator.requestMIDIAccess()
+}
+
+const mkMidiDevices = function (devices) {
+  return function (mk) {
+    return function () {
+      const res = [];
+      for (let device of devices.entries()) {
+        const portID = device[0];
+        const dev = device[1];
+        res.push(mk(portID)(dev.manufacturer)(dev.name))
+      }
+      return res;
+    }
+  }
+}
+
+exports.midiInputDevices_ = function (midiAccess) {
+  return mkMidiDevices(midiAccess.inputs)
+}
+
+exports.midiOutputDevices_ = function (midiAccess) {
+  return mkMidiDevices(midiAccess.outputs)
+}
 
 exports.getData_ = function (nothing) {
   return function (just) {

--- a/src/FRP/Event/MIDI.purs
+++ b/src/FRP/Event/MIDI.purs
@@ -120,9 +120,8 @@ midiInputDevices midiAccess_ =
   fromFoldable <$> midiInputDevices_ midiAccess_ mkMIDIDevice
 
 midiOutputDevices :: MIDIAccess -> Effect (List MIDIDevice)
-midiOutputDevices midiAccess_ = do
-  devices <- midiOutputDevices_ midiAccess_ mkMIDIDevice
-  pure $ fromFoldable devices
+midiOutputDevices midiAccess_ =
+  fromFoldable <$> midiOutputDevices_ midiAccess_ mkMIDIDevice
 
 -- | After having acquired the [MIDIAccess](https://developer.mozilla.org/en-US/docs/Web/API/MIDIAccess) from the browser, use it to create a streamed event of type `Event MIDIEventInTime`.
 midi :: MIDIAccess -> Event MIDIEventInTime

--- a/src/FRP/Event/MIDI.purs
+++ b/src/FRP/Event/MIDI.purs
@@ -116,9 +116,8 @@ fromEvent :: WE.Event -> Maybe MIDIMessageEvent
 fromEvent = unsafeReadProtoTagged "MIDIMessageEvent"
 
 midiInputDevices :: MIDIAccess -> Effect (List MIDIDevice)
-midiInputDevices midiAccess_ = do
-  devices <- midiInputDevices_ midiAccess_ mkMIDIDevice
-  pure $ fromFoldable devices
+midiInputDevices midiAccess_ =
+  fromFoldable <$> midiInputDevices_ midiAccess_ mkMIDIDevice
 
 midiOutputDevices :: MIDIAccess -> Effect (List MIDIDevice)
 midiOutputDevices midiAccess_ = do

--- a/src/FRP/Event/MIDI.purs
+++ b/src/FRP/Event/MIDI.purs
@@ -2,15 +2,19 @@ module FRP.Event.MIDI
   ( MIDIAccess(..)
   , MIDIEvent(..)
   , MIDIEventInTime(..)
+  , MIDIDevice
   , midi
   , midiAccess
+  , midiInputDevices
+  , midiOutputDevices
   ) where
 
 import Prelude
+
 import Control.Promise (Promise)
 import Data.ArrayBuffer.Types (ArrayBuffer)
 import Data.Foldable (traverse_)
-import Data.List (List)
+import Data.List (List, fromFoldable)
 import Data.Map as M
 import Data.Maybe (Maybe(..), maybe)
 import Data.Newtype (wrap)
@@ -40,6 +44,17 @@ type MIDIEventInTime
   , event :: MIDIEvent
   }
 
+-- | Represents a MIDI device.
+type MIDIDevice
+  =
+  { portID :: String
+  , manufacturer :: String
+  , name :: String
+  }
+
+mkMIDIDevice :: String -> String -> String -> MIDIDevice
+mkMIDIDevice portID manufacturer name = { portID, manufacturer, name }
+
 -- | The Web API's [MIDIAccess](https://developer.mozilla.org/en-US/docs/Web/API/MIDIAccess).
 foreign import data MIDIAccess :: Type
 
@@ -48,6 +63,16 @@ foreign import data MIDIMessageEvent :: Type
 
 -- | Get the [MIDIAccess](https://developer.mozilla.org/en-US/docs/Web/API/MIDIAccess) from the browser.
 foreign import midiAccess :: Effect (Promise MIDIAccess)
+
+foreign import midiInputDevices_
+  :: MIDIAccess
+  -> (String -> String -> String -> MIDIDevice)
+  -> Effect (Array MIDIDevice)
+
+foreign import midiOutputDevices_
+  :: MIDIAccess
+  -> (String -> String -> String -> MIDIDevice)
+  -> Effect (Array MIDIDevice)
 
 foreign import toTargetMap :: MIDIAccess -> Effect (O.Object EventTarget)
 
@@ -89,6 +114,16 @@ toMIDIEvent =
 
 fromEvent :: WE.Event -> Maybe MIDIMessageEvent
 fromEvent = unsafeReadProtoTagged "MIDIMessageEvent"
+
+midiInputDevices :: MIDIAccess -> Effect (List MIDIDevice)
+midiInputDevices midiAccess_ = do
+  devices <- midiInputDevices_ midiAccess_ mkMIDIDevice
+  pure $ fromFoldable devices
+
+midiOutputDevices :: MIDIAccess -> Effect (List MIDIDevice)
+midiOutputDevices midiAccess_ = do
+  devices <- midiOutputDevices_ midiAccess_ mkMIDIDevice
+  pure $ fromFoldable devices
 
 -- | After having acquired the [MIDIAccess](https://developer.mozilla.org/en-US/docs/Web/API/MIDIAccess) from the browser, use it to create a streamed event of type `Event MIDIEventInTime`.
 midi :: MIDIAccess -> Event MIDIEventInTime


### PR DESCRIPTION
This change adds a new binding to the FRP.Event.MIDI module and
updates the WTK example to display the available devices list.